### PR TITLE
Restore passwordless exam start

### DIFF
--- a/.github/workflows/server-image.yml
+++ b/.github/workflows/server-image.yml
@@ -14,7 +14,11 @@ env:
   IMAGE_NAME: ${{ github.repository }}-server
 
 jobs:
+  tests:
+    uses: ./.github/workflows/server-test.yml
+
   server-image:
+    needs: [tests]
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ dist
 .DS_Store
 
 # Codam specific
+.worktrees/
 dist/*
 build/*
 server/.env

--- a/client/uis/screen.ts
+++ b/client/uis/screen.ts
@@ -22,8 +22,6 @@ export interface UIExamModeElements {
 	examProjectsText: HTMLSpanElement;
 	examStartText: HTMLSpanElement;
 	examEndText: HTMLSpanElement;
-	loginInput: HTMLInputElement;
-	passwordInput: HTMLInputElement;
 	examStartButton: HTMLButtonElement;
 	examStartTimer: HTMLParagraphElement;
 }

--- a/client/uis/screens/examscreen.ts
+++ b/client/uis/screens/examscreen.ts
@@ -51,10 +51,6 @@ export class ExamModeUI extends UIScreen {
         "exam-mode-start",
       ) as HTMLSpanElement,
       examEndText: document.getElementById("exam-mode-end") as HTMLSpanElement,
-      loginInput: document.getElementById("exam-login") as HTMLInputElement,
-      passwordInput: document.getElementById(
-        "exam-password",
-      ) as HTMLInputElement,
       examStartButton: document.getElementById(
         "exam-mode-start-button",
       ) as HTMLButtonElement,
@@ -134,26 +130,11 @@ export class ExamModeUI extends UIScreen {
   protected _initForm(): void {
     const form = this._form as UIExamModeElements;
 
-    // Handle form submission so both button click and Enter key trigger the same flow.
     form.form.addEventListener("submit", (event: Event) => {
       event.preventDefault();
-      if (this._examMode) {
-        if (
-          form.loginInput.value === ExamModeUI.EXAM_USERNAME &&
-          form.passwordInput.value === ExamModeUI.EXAM_PASSWORD
-        ) {
-          this._auth.login(ExamModeUI.EXAM_USERNAME, ExamModeUI.EXAM_PASSWORD);
-        } else {
-          this._wigglePasswordInput();
-        }
+      if (this._examMode && !form.examStartButton.disabled) {
+        this._auth.login(ExamModeUI.EXAM_USERNAME, ExamModeUI.EXAM_PASSWORD);
       }
-    });
-
-    form.loginInput.addEventListener("input", () => {
-      this._enableOrDisableSubmitButton();
-    });
-    form.passwordInput.addEventListener("input", () => {
-      this._enableOrDisableSubmitButton();
     });
   }
 
@@ -263,26 +244,10 @@ export class ExamModeUI extends UIScreen {
     return buttonDisabled;
   }
 
-  protected _wigglePasswordInput(clearInput: boolean = true): void {
-    const passwordInput = (this._form as UIExamModeElements).passwordInput;
-    passwordInput.classList.add("wiggle");
-    passwordInput.addEventListener(
-      "keydown",
-      () => {
-        passwordInput.classList.remove("wiggle");
-      },
-      { once: true },
-    );
-
-    if (clearInput) {
-      passwordInput.value = "";
-      passwordInput.focus();
-      this._enableOrDisableSubmitButton();
-    }
-  }
+  protected _wigglePasswordInput(): void {}
 
   protected _getInputToFocusOn(): HTMLButtonElement | null {
-    return null; // Don't focus on any input field, there are none.
-    // There is a button we could focus on but then pressing enter/space will trigger the button even when the display is blanking
+    const form = this._form as UIExamModeElements;
+    return form.examStartButton.disabled ? null : form.examStartButton;
   }
 }

--- a/client/uis/screens/examscreen.ts
+++ b/client/uis/screens/examscreen.ts
@@ -25,7 +25,7 @@ export class ExamModeUI extends UIScreen {
     },
     authenticationFailure: () => {
       this._enableForm();
-      this._wigglePasswordInput();
+      this._enableOrDisableSubmitButton();
     },
     errorMessage: (message: string) => {
       alert(message);

--- a/docs/superpowers/plans/2026-07-30-passwordless-exam-start.md
+++ b/docs/superpowers/plans/2026-07-30-passwordless-exam-start.md
@@ -28,11 +28,11 @@
 - Consumes: `UIExamModeElements.examStartButton`, `ExamModeUI.EXAM_USERNAME`, and `ExamModeUI.EXAM_PASSWORD`.
 - Produces: a submit handler that calls `Authenticator.login(username, password)` only after the button is enabled.
 
-- [ ] **Step 1: Establish the current behavior**
+- [x] **Step 1: Establish the current behavior**
 
 Confirm `static/index.html` contains `#exam-login` and `#exam-password`, and `ExamModeUI._initForm()` rejects submission unless both values are `exam`.
 
-- [ ] **Step 2: Remove the input contract**
+- [x] **Step 2: Remove the input contract**
 
 Delete these HTML elements:
 
@@ -43,7 +43,7 @@ Delete these HTML elements:
 
 Delete `loginInput` and `passwordInput` from `UIExamModeElements`, their DOM lookups, the input listeners, and `_wigglePasswordInput` from `ExamModeUI`.
 
-- [ ] **Step 3: Make the enabled button submit directly**
+- [x] **Step 3: Make the enabled button submit directly**
 
 ```ts
 form.form.addEventListener("submit", (event: Event) => {
@@ -56,7 +56,7 @@ form.form.addEventListener("submit", (event: Event) => {
 
 Change `_getInputToFocusOn()` to return `form.examStartButton` only when it is enabled; otherwise return `null`. Remove its duplicate focus call from `_enableOrDisableSubmitButton()`.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run:
 
@@ -68,7 +68,7 @@ git diff --check
 
 Expected: the TypeScript client and bundle compile; no whitespace errors; there are no references to `exam-login`, `exam-password`, `loginInput`, or `passwordInput` in exam-mode code.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add static/index.html client/uis/screen.ts client/uis/screens/examscreen.ts

--- a/docs/superpowers/plans/2026-07-30-passwordless-exam-start.md
+++ b/docs/superpowers/plans/2026-07-30-passwordless-exam-start.md
@@ -1,0 +1,76 @@
+# Passwordless Exam Start Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Start the fixed exam account from the enabled exam button without visible credentials.
+
+**Architecture:** Remove the exam-only fields from HTML and `UIExamModeElements`. Keep the existing form submit event, but have it call the fixed-account authentication only if exam mode is active and the countdown has enabled the button.
+
+**Tech Stack:** TypeScript and static HTML.
+
+## Global Constraints
+
+- Keep `ExamModeUI.EXAM_USERNAME` and `ExamModeUI.EXAM_PASSWORD` unchanged.
+- Do not change regular login or lock-screen inputs.
+- Preserve the existing countdown gate by rejecting submits while `examStartButton.disabled` is true.
+
+---
+
+### Task 1: Remove exam credentials from the UI and submit flow
+
+**Files:**
+- Modify: `static/index.html:51-60`
+- Modify: `client/uis/screen.ts:20-30`
+- Modify: `client/uis/screens/examscreen.ts:45-65,134-157,250-285`
+- Test: `npm run build`
+
+**Interfaces:**
+- Consumes: `UIExamModeElements.examStartButton`, `ExamModeUI.EXAM_USERNAME`, and `ExamModeUI.EXAM_PASSWORD`.
+- Produces: a submit handler that calls `Authenticator.login(username, password)` only after the button is enabled.
+
+- [ ] **Step 1: Establish the current behavior**
+
+Confirm `static/index.html` contains `#exam-login` and `#exam-password`, and `ExamModeUI._initForm()` rejects submission unless both values are `exam`.
+
+- [ ] **Step 2: Remove the input contract**
+
+Delete these HTML elements:
+
+```html
+<input type="text" name="login" id="exam-login" placeholder="Enter the login" maxlength="32" />
+<input type="password" name="password" id="exam-password" placeholder="Enter the password" maxlength="128" />
+```
+
+Delete `loginInput` and `passwordInput` from `UIExamModeElements`, their DOM lookups, the input listeners, and `_wigglePasswordInput` from `ExamModeUI`.
+
+- [ ] **Step 3: Make the enabled button submit directly**
+
+```ts
+form.form.addEventListener("submit", (event: Event) => {
+  event.preventDefault();
+  if (this._examMode && !form.examStartButton.disabled) {
+    this._auth.login(ExamModeUI.EXAM_USERNAME, ExamModeUI.EXAM_PASSWORD);
+  }
+});
+```
+
+Change `_getInputToFocusOn()` to return `form.examStartButton` only when it is enabled; otherwise return `null`. Remove its duplicate focus call from `_enableOrDisableSubmitButton()`.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+npm run build
+npm run bundle
+git diff --check
+```
+
+Expected: the TypeScript client and bundle compile; no whitespace errors; there are no references to `exam-login`, `exam-password`, `loginInput`, or `passwordInput` in exam-mode code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add static/index.html client/uis/screen.ts client/uis/screens/examscreen.ts
+git commit -m "Restore passwordless exam start"
+```

--- a/docs/superpowers/plans/2026-07-30-static-exam-countdown.md
+++ b/docs/superpowers/plans/2026-07-30-static-exam-countdown.md
@@ -26,11 +26,11 @@
 - Consumes: `switchScreen(screenId)`, `#exam-mode-start-timer`, and `#exam-mode-start-button`.
 - Produces: `startExamCountdown()` and `clearExamCountdown()` used only by `switchScreen`.
 
-- [ ] **Step 1: Establish the current failure**
+- [x] **Step 1: Establish the current failure**
 
 Open `static/index.html`, select **Exam mode**, and verify the text remains `Click the arrow below to start your exam.` while the arrow remains enabled.
 
-- [ ] **Step 2: Add the minimal countdown state and helpers**
+- [x] **Step 2: Add the minimal countdown state and helpers**
 
 ```js
 let examCountdownInterval = null;
@@ -60,7 +60,7 @@ function startExamCountdown() {
 
 Use `examStartTimer.innerText = \`You may start your exam in ${secondsRemaining} seconds.\`;`. When it reaches zero, clear the interval, restore `Click the arrow below to start your exam.`, and set `examStartButton.disabled = false`.
 
-- [ ] **Step 3: Connect it to screen changes**
+- [x] **Step 3: Connect it to screen changes**
 
 ```js
 if (screenId === 'exam-form') {
@@ -72,11 +72,11 @@ if (screenId === 'exam-form') {
 
 Place this in `switchScreen` after selecting the form. Set `examStartButton.disabled = true` before rendering the first countdown value.
 
-- [ ] **Step 4: Verify the preview behavior**
+- [x] **Step 4: Verify the preview behavior**
 
 Open `static/index.html`, select **Exam mode**, and confirm: the arrow is disabled immediately; the text starts at 30 seconds and decrements once per second; the arrow enables after 30 seconds; selecting Login and returning to Exam restarts at 30 seconds without duplicate updates.
 
-- [ ] **Step 5: Verify production scope and commit**
+- [x] **Step 5: Verify production scope and commit**
 
 Run:
 

--- a/docs/superpowers/plans/2026-07-30-static-exam-countdown.md
+++ b/docs/superpowers/plans/2026-07-30-static-exam-countdown.md
@@ -1,0 +1,90 @@
+# Static Exam Countdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the browser-only static preview show a 30-second exam-start countdown.
+
+**Architecture:** Keep the behavior in `static/debug.js`, which is loaded only when the production bundle is unavailable. The existing screen switcher starts and clears one interval; it updates the existing timer element and arrow button.
+
+**Tech Stack:** Browser DOM APIs and plain JavaScript.
+
+## Global Constraints
+
+- Modify only `static/debug.js`; do not alter the bundled client or installed greeter behavior.
+- Use the existing `exam-mode-start-timer` and `exam-mode-start-button` elements.
+- The demo duration is exactly 30 seconds and resets whenever Exam mode is selected.
+
+---
+
+### Task 1: Add the preview countdown
+
+**Files:**
+- Modify: `static/debug.js:1-115`
+- Test: Manual browser check of `static/index.html`
+
+**Interfaces:**
+- Consumes: `switchScreen(screenId)`, `#exam-mode-start-timer`, and `#exam-mode-start-button`.
+- Produces: `startExamCountdown()` and `clearExamCountdown()` used only by `switchScreen`.
+
+- [ ] **Step 1: Establish the current failure**
+
+Open `static/index.html`, select **Exam mode**, and verify the text remains `Click the arrow below to start your exam.` while the arrow remains enabled.
+
+- [ ] **Step 2: Add the minimal countdown state and helpers**
+
+```js
+let examCountdownInterval = null;
+
+function clearExamCountdown() {
+	clearInterval(examCountdownInterval);
+	examCountdownInterval = null;
+}
+
+function startExamCountdown() {
+	clearExamCountdown();
+	let secondsRemaining = 30;
+	examStartButton.disabled = true;
+	examStartTimer.innerText = `You may start your exam in ${secondsRemaining} seconds.`;
+	examCountdownInterval = setInterval(() => {
+		secondsRemaining -= 1;
+		if (secondsRemaining === 0) {
+			clearExamCountdown();
+			examStartTimer.innerText = 'Click the arrow below to start your exam.';
+			examStartButton.disabled = false;
+			return;
+		}
+		examStartTimer.innerText = `You may start your exam in ${secondsRemaining} seconds.`;
+	}, 1000);
+}
+```
+
+Use `examStartTimer.innerText = \`You may start your exam in ${secondsRemaining} seconds.\`;`. When it reaches zero, clear the interval, restore `Click the arrow below to start your exam.`, and set `examStartButton.disabled = false`.
+
+- [ ] **Step 3: Connect it to screen changes**
+
+```js
+if (screenId === 'exam-form') {
+	startExamCountdown();
+} else {
+	clearExamCountdown();
+}
+```
+
+Place this in `switchScreen` after selecting the form. Set `examStartButton.disabled = true` before rendering the first countdown value.
+
+- [ ] **Step 4: Verify the preview behavior**
+
+Open `static/index.html`, select **Exam mode**, and confirm: the arrow is disabled immediately; the text starts at 30 seconds and decrements once per second; the arrow enables after 30 seconds; selecting Login and returning to Exam restarts at 30 seconds without duplicate updates.
+
+- [ ] **Step 5: Verify production scope and commit**
+
+Run:
+
+```bash
+npm run build
+git diff --check
+git add static/debug.js
+git commit -m "Add static exam countdown preview"
+```
+
+Expected: TypeScript build succeeds, whitespace check succeeds, and only the preview script changes for this feature.

--- a/docs/superpowers/specs/2026-07-30-passwordless-exam-start-design.md
+++ b/docs/superpowers/specs/2026-07-30-passwordless-exam-start-design.md
@@ -1,0 +1,20 @@
+# Passwordless Exam Start
+
+## Scope
+
+Restore the upstream passwordless exam-start interaction.
+
+## Behavior
+
+- The exam screen has no login or password fields.
+- Submitting the enabled start button authenticates with the existing fixed `exam` account credentials.
+- The existing countdown remains the only start-time gate; submission while its button is disabled does nothing.
+- When the button becomes enabled, it receives focus.
+
+## Boundaries
+
+Update only the exam-screen HTML and TypeScript interfaces/behavior. Do not change the credentials, server API, or regular login/lock screens.
+
+## Verification
+
+The client bundle builds successfully. In an exam-mode greeter session, the button is disabled before `begin_at`, then starts the fixed `exam` session after `begin_at` without visible credential inputs.

--- a/docs/superpowers/specs/2026-07-30-static-exam-countdown-design.md
+++ b/docs/superpowers/specs/2026-07-30-static-exam-countdown-design.md
@@ -1,0 +1,20 @@
+# Static Exam Countdown Preview
+
+## Scope
+
+Add a browser-preview-only 30-second exam countdown in `static/debug.js`.
+
+## Behavior
+
+- Selecting **Exam mode** disables the existing arrow button and starts at 30 seconds.
+- The existing timer text updates once each second.
+- At zero, the arrow is enabled and the normal start message is restored.
+- Switching away from exam mode clears the active interval; selecting it again starts a fresh demo.
+
+## Boundaries
+
+Only `static/debug.js` changes. The bundled client and installed greeter behavior are unchanged.
+
+## Verification
+
+Open `static/index.html`, select **Exam mode**, and confirm the visible countdown reaches zero and enables the arrow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,16 +1111,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -1181,27 +1171,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -1235,16 +1204,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -1363,16 +1322,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+      "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1088,10 +1088,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codam-web-greeter",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codam-web-greeter",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "devDependencies": {
         "nody-greeter-types": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -719,9 +719,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.3.7",
       "license": "MIT",
       "devDependencies": {
+        "@types/node": "14.18.63",
         "nody-greeter-types": "^1.1.0",
         "ts-loader": "^9.5.0",
         "typescript": "^4.9.5",
@@ -112,14 +113,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.1.tgz",
-      "integrity": "sha512-CPrnr8voK8vC6eEtyRzvMpgp3VyVRhgclonE7qYi6P9sXwYb59ucfrnmFBTaP0yUi8Gk4yZg/LlTJULGxvTNsg==",
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -1409,13 +1407,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -717,9 +717,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codam-web-greeter",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "LightDM greeter theme for Codam Coding College, compatible with nody-greeter and web-greeter",
   "main": "main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/codam-coding-college/codam-web-greeter#readme",
   "devDependencies": {
+    "@types/node": "14.18.63",
     "nody-greeter-types": "^1.1.0",
     "ts-loader": "^9.5.0",
     "typescript": "^4.9.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codam-web-greeter-server",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codam-web-greeter-server",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "@codam/fast42": "^2.1.6",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@codam/fast42": "^2.1.6",
         "dotenv": "^16.3.1",
-        "express": "^4.22.1",
+        "express": "^4.22.2",
         "ip-range-check": "^0.2.0",
         "node-cache": "^5.1.2"
       },
@@ -192,21 +192,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/body-parser/node_modules/statuses": {
@@ -411,14 +396,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -437,7 +422,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -775,9 +760,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -151,32 +151,78 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -410,21 +456,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -559,6 +590,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -743,11 +775,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -765,15 +798,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -842,7 +905,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "0.19.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -151,9 +151,9 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codam-web-greeter-server",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Back-end server for the codam-web-greeter",
   "main": "src/server.js",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@codam/fast42": "^2.1.6",
     "dotenv": "^16.3.1",
-    "express": "^4.22.1",
+    "express": "^4.22.2",
     "ip-range-check": "^0.2.0",
     "node-cache": "^5.1.2"
   },

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -31,14 +31,10 @@ export default (app: Express) => {
 		let lastCacheChange = cache.get<Date>('last-cache-change');
 
 		if (!events && api) {
-			events = await fetchEvents(api);
-			cache.set('events', events);
-			cache.set('last-cache-change', new Date());
+			events = await fetchCacheEvents();
 		}
 		if (!exams && api) {
-			exams = await fetchExams(api);
-			cache.set('exams', exams);
-			cache.set('last-cache-change', new Date());
+			exams = await fetchCacheExams();
 		}
 
 		if (events === undefined || exams === undefined) {
@@ -73,9 +69,7 @@ export default (app: Express) => {
 		// Get the current exams
 		let exams = cache.get<Exam42[]>('exams');
 		if (!exams && api) {
-			exams = await fetchExams(api);
-			cache.set('exams', exams);
-			cache.set('last-cache-change', new Date());
+			exams = await fetchCacheExams();
 		}
 		if (exams === undefined) {
 			return res.status(503).send({ error: 'No data to return, try again later', status: 'error' });
@@ -130,6 +124,52 @@ export default (app: Express) => {
 	});
 };
 
+const fetchCacheEvents = async function() {
+	if (!api) {
+		console.warn('Intra API not initialized, cannot fetch events');
+		return undefined;
+	}
+
+	try {
+		const events = await fetchEvents(api);
+		cache.set('events', events);
+		cache.set('last-cache-change', new Date());
+		console.log('Refreshed events data');
+		return events;
+	} catch (err) {
+		console.error('Error refreshing events data:', err);
+	}
+	return undefined;
+};
+
+const fetchCacheExams = async function() {
+	if (!api) {
+		console.warn('Intra API not initialized, cannot fetch exams');
+		return undefined;
+	}
+
+	try {
+		const exams = await fetchExams(api);
+		cache.set('exams', exams);
+		cache.set('last-cache-change', new Date());
+		console.log('Refreshed exams data');
+		return exams;
+	} catch (err) {
+		console.error('Error refreshing exams data:', err);
+	}
+	return undefined;
+};
+
+const fetchCacheEventsAndExams = async () => {
+	if (!api) {
+		console.warn('Intra API not initialized, cannot fetch events and exams');
+		return;
+	}
+
+	await Promise.all([fetchCacheEvents(), fetchCacheExams()]);
+};
+
+
 const setUpIntraAPI = async function() {
 	try {
 		console.log(`Using Intra API UID: ${process.env.INTRA_API_UID}`);
@@ -140,19 +180,16 @@ const setUpIntraAPI = async function() {
 		}]).init();
 
 		// Fetch initial data
-		if (!cache.has('events')) {
-			const events = await fetchEvents(api);
-			console.log('Fetched future events');
-			cache.set('events', events);
-			cache.set('last-cache-change', new Date());
+		if (!cache.has('events') || !cache.has('exams')) {
+			await fetchCacheEventsAndExams();
 		}
 
-		if (!cache.has('exams')) {
-			const exams = await fetchExams(api);
-			console.log('Fetched future exams');
-			cache.set('exams', exams);
-			cache.set('last-cache-change', new Date());
-		}
+		// Fetch events and exams to prevent cache expiration while the server is running
+		setInterval(async () => {
+			if (!api) return; // If API is not initialized, skip this fetch
+			console.log('Refreshing events and exams data from Intra API to prevent cache expiration...');
+			await fetchCacheEventsAndExams();
+		}, cacheTTL * 1000 - 5000); // Convert TTL to milliseconds
 	}
 	catch(err) {
 		console.warn("[WARNING] Could not initialize Intra API, some features might not work");

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -14,9 +14,9 @@ const cache = new NodeCache({ stdTTL: cacheTTL });
 
 const FOUND_HOSTS: string[] = [];
 
-export default (app: Express) => {
+export default async (app: Express) => {
 	// Initialize
-	setUpIntraAPI();
+	await setUpIntraAPI();
 
 	// Define routes
 	app.get('/', (req, res) => {

--- a/static/debug.js
+++ b/static/debug.js
@@ -11,6 +11,32 @@ message.innerText = 'This is a test message that could have been sent by the bac
 const examModeProjects = document.getElementById('exam-mode-projects');
 examModeProjects.innerText = 'Exam Rank 00, Exam Rank 01, Exam Rank 02, non-existing debug exams';
 
+const examStartTimer = document.getElementById('exam-mode-start-timer');
+const examStartButton = document.getElementById('exam-mode-start-button');
+let examCountdownInterval = null;
+
+function clearExamCountdown() {
+	clearInterval(examCountdownInterval);
+	examCountdownInterval = null;
+}
+
+function startExamCountdown() {
+	clearExamCountdown();
+	let secondsRemaining = 30;
+	examStartButton.disabled = true;
+	examStartTimer.innerText = `You may start your exam in ${secondsRemaining} seconds.`;
+	examCountdownInterval = setInterval(() => {
+		secondsRemaining -= 1;
+		if (secondsRemaining === 0) {
+			clearExamCountdown();
+			examStartTimer.innerText = 'Click the arrow below to start your exam.';
+			examStartButton.disabled = false;
+			return;
+		}
+		examStartTimer.innerText = `You may start your exam in ${secondsRemaining} seconds.`;
+	}, 1000);
+}
+
 const lockedAgo = document.getElementById('active-user-session-locked-ago');
 lockedAgo.innerText = 'Automated logout occurs in 42 minutes';
 
@@ -38,10 +64,15 @@ function switchScreen(screenId) {
 			screen.style.display = 'none';
 		});
 
-		const selectedScreen = document.getElementById(screenId);
-		selectedScreen.style.display = 'block';
+	const selectedScreen = document.getElementById(screenId);
+	selectedScreen.style.display = 'block';
+	if (screenId === 'exam-form') {
+		startExamCountdown();
+	} else {
+		clearExamCountdown();
+	}
 
-		logo.style.display = (screenId === 'lock-form') ? 'none' : 'block';
+	logo.style.display = (screenId === 'lock-form') ? 'none' : 'block';
 
 		// Make sure the correct input field is checked
 		const selectedInput = document.getElementById(`radio-${screenId}`);

--- a/static/index.html
+++ b/static/index.html
@@ -53,8 +53,6 @@
 				<h3>This computer is reserved for an exam between <span id="exam-mode-start">...</span> and <span id="exam-mode-end">...</span>.</h3>
 				<p><span id="exam-mode-projects"></span></p>
 				<br>
-				<input type="text" name="login" id="exam-login" placeholder="Enter the login" maxlength="32" />
-				<input type="password" name="password" id="exam-password" placeholder="Enter the password" maxlength="128" />
 				<p id="exam-mode-start-timer">Click the arrow below to start your exam.</p>
 				<button type="submit" id="exam-mode-start-button" title="Start your exam">&#10149;</button>
 				<div id="exam-mode-stripe">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": [],                                         /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],            /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": [],                                         /* Specify type package names to be included without being referenced in a source file. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
## What changed

- Removed the visible username and password fields from the exam screen.
- Starts the fixed `exam` account from the enabled exam button.
- Keeps the existing exam-start countdown as the gate.

## Why

The local exam screen had diverged from upstream by requiring users to type fixed credentials before starting an exam.

## Validation

- `npm test`
